### PR TITLE
Make pop reset cursor so later pops are correct

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -34,6 +34,7 @@ impl MockStream {
 	pub fn pop_bytes_written(&mut self) -> Vec<u8> {
 		let mut result = Vec::new();
 		swap(&mut result, self.writer.get_mut());
+		self.writer.set_position(0);
 		result
 	}
 

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -12,6 +12,15 @@ fn test_mock_stream_read() {
 }
 
 #[test]
+fn test_mock_stream_pop_again() {
+	let mut s = MockStream::new();
+	s.write_all(b"abcd").unwrap();
+	assert_eq!(s.pop_bytes_written(), b"abcd");
+	s.write_all(b"efgh").unwrap();
+	assert_eq!(s.pop_bytes_written(), b"efgh");
+}
+
+#[test]
 fn test_mock_stream_empty_and_fill() {
 	let mut s = MockStream::new();
 	let mut v = [11; 6];


### PR DESCRIPTION
Currently, `pop_bytes_written` does not reset the underlying `Cursor`, which means that subsequent calls to `pop_bytes_written` start with a large number of leading zeroes. This patch fixes that behavior, and includes a regression test.