### PR TITLE
Bump version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "mockstream"
-version = "0.0.2"
+version = "0.0.3"
 authors = ["Alex Bogma <bitfield.alex@gmail.com>"]
 license = "MIT"
 description = "Stream (Read+Write traits) implementations to be used to mock real streams in tests."


### PR DESCRIPTION
To make changes such as #3, #5, #6, and #7 visible, the version number should be incremented.
You then also have to run `cargo publish` to make the new version available on crates.io